### PR TITLE
Load zfile index in file header.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Or just
 The image file should be LSMT-File on ZFile, image path can be configured by parameter.
 Currently it supports only one-layer image.
 
-`insmod ./vdo.ko backfile=<image file absolute path>`
+`insmod ./vbd.ko backfile=<image file absolute path>`
 
 if succeed, a read-only device called `/dev/vbd0` should appeared, 
 

--- a/zfile.h
+++ b/zfile.h
@@ -17,6 +17,7 @@ struct compress_options {
 	uint8_t verify; // 16
 };
 
+
 _Static_assert(20 == sizeof(struct compress_options), "CO size not fit");
 
 struct _UUID {
@@ -43,12 +44,13 @@ struct zfile_ht {
 	struct compress_options opt; // suppose to be 24
 };
 
+
 _Static_assert(96 == sizeof(struct zfile_ht), "Header size not fit");
 
 struct jump_table {
-	uint64_t partial_offset; // 48 bits logical offset + 16 bits partial minimum
-	uint16_t delta;
-};
+	uint64_t partial_offset : 48;  // 48 bits logical offset + 16 bits partial minimum
+	uint16_t delta : 16; 
+} __attribute__((packed));
 
 // zfile can be treated as file with extends
 struct zfile {
@@ -69,7 +71,7 @@ struct zfile *zfile_open(const char *path);
 
 struct zfile *zfile_open_by_file(struct file *file);
 
-bool is_zfile(struct file *file);
+bool is_zfile(struct file *file, struct zfile_ht *ht);
 
 void zfile_close(struct vfile *zfile);
 struct path zfile_getpath(struct zfile *zfile);


### PR DESCRIPTION
In the latest ZFile format, index will be saved in file header. 
So, the kernel module can also read ZFile index from its header
if the tag 'FLAG_SHIFT_HEADER_OVERWRITE' is set.

Signed-off-by: Yifan Yuan <tuji.yyf@alibaba-inc.com>